### PR TITLE
Handle image updates when editing bible content

### DIFF
--- a/src/main/java/com/example/ezra/services/BibleContentService.java
+++ b/src/main/java/com/example/ezra/services/BibleContentService.java
@@ -124,10 +124,23 @@ public class BibleContentService {
                     existingContent.setType(updatedContent.getType());
                     existingContent.setChapterGroup(updatedContent.getChapterGroup());
                     existingContent.setBook(updatedContent.getBook());
-                    if (updatedContent.getImage() != null && updatedContent.getImage().getId() == null) {
-                        Image savedImage = imageRepository.save(updatedContent.getImage());
-                        updatedContent.setImage(savedImage);
+
+                    // Handle image updates
+                    if (updatedContent.getImage() == null) {
+                        // Remove existing image if frontend sends null
+                        existingContent.setImage(null);
+                    } else {
+                        Image imageToSet = updatedContent.getImage();
+
+                        // If image ID is null or does not exist, save as a new image
+                        if (imageToSet.getId() == null || !imageRepository.existsById(imageToSet.getId())) {
+                            imageToSet.setId(null); // Ensure JPA generates a new ID
+                            imageToSet = imageRepository.save(imageToSet);
+                        }
+
+                        existingContent.setImage(imageToSet);
                     }
+
                     existingContent.setContent(updatedContent.getContent());
                     existingContent.setMetadata(updatedContent.getMetadata());
                     return bibleContentRepository.save(existingContent);


### PR DESCRIPTION
## Summary
- allow bible content image to be removed or replaced
- save new images when provided without existing records

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68904e65dd988323b63ee4de155a9859