### PR TITLE
feat: support bulk content deletion

### DIFF
--- a/src/main/java/com/example/ezra/controllers/BibleContentController.java
+++ b/src/main/java/com/example/ezra/controllers/BibleContentController.java
@@ -2,6 +2,7 @@ package com.example.ezra.controllers;
 
 import com.example.ezra.helpers.PagedResponse;
 import com.example.ezra.models.chapterModel.BibleContent;
+import com.example.ezra.dtos.BulkContentUpdateRequest;
 import com.example.ezra.services.BibleContentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -45,9 +46,10 @@ public class BibleContentController {
     }
 
     @PutMapping("/bulk-update")
-    public ResponseEntity<List<BibleContent>> updateMultipleContents(@RequestBody List<BibleContent> updates, @RequestHeader("Authorization") String bearerToken) {
+    public ResponseEntity<List<BibleContent>> updateMultipleContents(@RequestBody BulkContentUpdateRequest request,
+                                                                    @RequestHeader("Authorization") String bearerToken) {
         String token = extractToken(bearerToken);
-        List<BibleContent> updatedContents = bibleContentService.updateMultipleContents(updates, token);
+        List<BibleContent> updatedContents = bibleContentService.updateMultipleContents(request.getUpdates(), request.getDeleteIds(), token);
         return ResponseEntity.ok(updatedContents);
     }
 

--- a/src/main/java/com/example/ezra/dtos/BulkContentUpdateRequest.java
+++ b/src/main/java/com/example/ezra/dtos/BulkContentUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.example.ezra.dtos;
+
+import com.example.ezra.models.chapterModel.BibleContent;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Request payload for bulk updating bible content.
+ * Contains a list of content updates and optional IDs to delete.
+ */
+@Data
+@NoArgsConstructor
+public class BulkContentUpdateRequest {
+    private List<BibleContent> updates;
+    private List<Long> deleteIds;
+}
+


### PR DESCRIPTION
## Summary
- add BulkContentUpdateRequest to carry updates and IDs to delete
- allow updateMultipleContents to process deletions
- expose optional deleteIds via bulk-update controller endpoint

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68905109f1f48323a1f147962b03ab65